### PR TITLE
Fix for not working with WPML. 

### DIFF
--- a/includes/class-relevanssi-live-search-client.php
+++ b/includes/class-relevanssi-live-search-client.php
@@ -151,7 +151,10 @@ class Relevanssi_Live_Search_Client extends Relevanssi_Live_Search {
 			// environment for our template loader, allowing the developer to
 			// utilize everything they normally would in a theme template (and
 			// reducing support requests).
+			remove_filter( 'wpml_active_languages', 'wpml_get_active_languages_filter' );
 			query_posts( $args ); // phpcs:ignore WordPress.WP.DiscouragedFunctions
+			add_filter( 'wpml_active_languages', 'wpml_get_active_languages_filter', 10, 2 );
+
 			$template = 'search-results';
 		} else {
 			global $relevanssi_query;


### PR DESCRIPTION
Also see: https://wpml.org/forums/topic/compatibility-problem-with-relevanssi-live-ajax-search-and-wpml/

The deeper issue is in `\SitePress::get_ls_languages()` where the `global $wp_query` is reset twice.
This is not fully tested and might have unforeseen consequences.