### PR TITLE
Allow injecting content next to the Ajax results

### DIFF
--- a/templates/search-results-query.php
+++ b/templates/search-results-query.php
@@ -61,7 +61,8 @@ if ( $relevanssi_query->have_posts() ) {
 		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false" data-postype="<?php echo esc_attr( get_post_type() ); ?>" data-postid="<?php echo esc_attr( $relevanssi_post_id ); ?>" data-termid="<?php echo esc_attr( $relevanssi_term_id ); ?>">
 			<p>
 				<a href="<?php the_permalink(); ?>">
-					<?php the_title(); ?> &raquo;
+					<?php the_title(); ?>
+					<?php echo wp_kses_post( apply_filters( 'relevanssi_live_search_result_arrow', '&raquo;', $post ) ); ?>
 				</a>
 			</p>
 		</div>

--- a/templates/search-results-query.php
+++ b/templates/search-results-query.php
@@ -59,12 +59,18 @@ if ( $relevanssi_query->have_posts() ) {
 		$relevanssi_term_id = isset( $post->term_id ) && intval( $post->term_id ) > 0 ? intval( $post->term_id ) : '';
 		?>
 		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false" data-postype="<?php echo esc_attr( get_post_type() ); ?>" data-postid="<?php echo esc_attr( $relevanssi_post_id ); ?>" data-termid="<?php echo esc_attr( $relevanssi_term_id ); ?>">
+			<?php do_action( 'relevanssi_live_search_before_result', $post ); ?>
 			<p>
+				<?php do_action( 'relevanssi_live_search_before_result_link', $post ); ?>
 				<a href="<?php the_permalink(); ?>">
+					<?php do_action( 'relevanssi_live_search_before_result_title', $post ); ?>
 					<?php the_title(); ?>
 					<?php echo wp_kses_post( apply_filters( 'relevanssi_live_search_result_arrow', '&raquo;', $post ) ); ?>
+					<?php do_action( 'relevanssi_live_search_after_result_title', $post ); ?>
 				</a>
+				<?php do_action( 'relevanssi_live_search_after_result_link', $post ); ?>
 			</p>
+			<?php do_action( 'relevanssi_live_search_after_result', $post ); ?>
 		</div>
 		<?php
 	}

--- a/templates/search-results-query.php
+++ b/templates/search-results-query.php
@@ -55,12 +55,16 @@ if ( $relevanssi_query->have_posts() ) {
 
 	while ( $relevanssi_query->have_posts() ) {
 		$relevanssi_query->the_post();
+		$relevanssi_post_id = get_the_ID() > 0 ? intval( get_the_ID() ) : '';
+		$relevanssi_term_id = isset( $post->term_id ) && intval( $post->term_id ) > 0 ? intval( $post->term_id ) : '';
 		?>
-	<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false">
-		<p><a href="<?php the_permalink(); ?>">
-			<?php the_title(); ?> &raquo;
-		</a></p>
-	</div>
+		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false" data-postype="<?php echo esc_attr( get_post_type() ); ?>" data-postid="<?php echo esc_attr( $relevanssi_post_id ); ?>" data-termid="<?php echo esc_attr( $relevanssi_term_id ); ?>">
+			<p>
+				<a href="<?php the_permalink(); ?>">
+					<?php the_title(); ?> &raquo;
+				</a>
+			</p>
+		</div>
 		<?php
 	}
 

--- a/templates/search-results.php
+++ b/templates/search-results.php
@@ -59,11 +59,15 @@
 
 	while ( have_posts() ) :
 		the_post();
+		$relevanssi_post_id = get_the_ID() > 0 ? intval( get_the_ID() ) : '';
+		$relevanssi_term_id = isset( $post->term_id ) && intval( $post->term_id ) > 0 ? intval( $post->term_id ) : '';
 		?>
-		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false">
-			<p><a href="<?php echo esc_url( get_permalink() ); ?>">
-				<?php the_title(); ?> &raquo;
-			</a></p>
+		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false" data-postype="<?php echo esc_attr( get_post_type() ); ?>" data-postid="<?php echo esc_attr( $relevanssi_post_id ); ?>" data-termid="<?php echo esc_attr( $relevanssi_term_id ); ?>">
+			<p>
+				<a href="<?php echo esc_url( get_permalink() ); ?>">
+					<?php the_title(); ?> &raquo;
+				</a>
+			</p>
 		</div>
 		<?php
 	endwhile;

--- a/templates/search-results.php
+++ b/templates/search-results.php
@@ -65,7 +65,8 @@
 		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false" data-postype="<?php echo esc_attr( get_post_type() ); ?>" data-postid="<?php echo esc_attr( $relevanssi_post_id ); ?>" data-termid="<?php echo esc_attr( $relevanssi_term_id ); ?>">
 			<p>
 				<a href="<?php echo esc_url( get_permalink() ); ?>">
-					<?php the_title(); ?> &raquo;
+					<?php the_title(); ?>
+					<?php echo wp_kses_post( apply_filters( 'relevanssi_live_search_result_arrow', '&raquo;', $post ) ); ?>
 				</a>
 			</p>
 		</div>

--- a/templates/search-results.php
+++ b/templates/search-results.php
@@ -63,12 +63,18 @@
 		$relevanssi_term_id = isset( $post->term_id ) && intval( $post->term_id ) > 0 ? intval( $post->term_id ) : '';
 		?>
 		<div class="relevanssi-live-search-result" role="option" id="" aria-selected="false" data-postype="<?php echo esc_attr( get_post_type() ); ?>" data-postid="<?php echo esc_attr( $relevanssi_post_id ); ?>" data-termid="<?php echo esc_attr( $relevanssi_term_id ); ?>">
+			<?php do_action( 'relevanssi_live_search_before_result', $post ); ?>
 			<p>
-				<a href="<?php echo esc_url( get_permalink() ); ?>">
+				<?php do_action( 'relevanssi_live_search_before_result_link', $post ); ?>
+				<a href="<?php the_permalink(); ?>">
+					<?php do_action( 'relevanssi_live_search_before_result_title', $post ); ?>
 					<?php the_title(); ?>
 					<?php echo wp_kses_post( apply_filters( 'relevanssi_live_search_result_arrow', '&raquo;', $post ) ); ?>
+					<?php do_action( 'relevanssi_live_search_after_result_title', $post ); ?>
 				</a>
+				<?php do_action( 'relevanssi_live_search_after_result_link', $post ); ?>
 			</p>
+			<?php do_action( 'relevanssi_live_search_after_result', $post ); ?>
 		</div>
 		<?php
 	endwhile;


### PR DESCRIPTION
This PR closes #21, allowing 3rd parties to inject content next to the Ajax results.

It creates the following hooks:
- Action `relevanssi_live_search_before_result` before the P tag of each result
- Action `relevanssi_live_search_before_result_link`, inside P, before the A tag of each result
- Action `relevanssi_live_search_before_result_title`, inside A, before the result title
- Filter `relevanssi_live_search_result_arrow`, after the result title, to allow replacing/removing the &raquo; element
- Action `relevanssi_live_search_after_result_title` after the title
- Action `relevanssi_live_search_after_result_link` after the link
- Action `relevanssi_live_search_after_result` after the P tag

Additionally, it adds data attributes to the outer DIV of each result, to allow for CSS or JS targeting:
- `data-postype` with the result post/term type
- `data-postid` with the post ID, in case the result is a post
- `data-termid` with the term ID, in case the result is a taxonomy term

Example of what can be achieved:
<img width="1132" height="530" alt="image" src="https://github.com/user-attachments/assets/4a67b53d-c84e-450e-9b5d-680a7b1bfbe3" />
